### PR TITLE
Check home folder for git before submitting

### DIFF
--- a/src/submit.py
+++ b/src/submit.py
@@ -31,11 +31,13 @@ async def _git_push(repo_dir: pathlib.Path) -> tuple[int, str]:
 
 
 async def _create_submission_commit(repo_dir: pathlib.Path):
-    await run_command(["git", "stash", "push"], repo_dir)
-
-    await run_command(["git", "commit", "--allow-empty", "-m", "SUBMISSION"], repo_dir)
-
-    await run_command(["git", "stash", "pop"], repo_dir)
+    commands = [
+        ["git", "stash", "push"],
+        ["git", "commit", "--allow-empty", "-m", "SUBMISSION"],
+        ["git", "stash", "pop"],
+    ]
+    for command in commands:
+        await run_command(command, repo_dir)
 
 
 async def git_clone_instructions(repo_dir: pathlib.Path):

--- a/src/submit.py
+++ b/src/submit.py
@@ -32,15 +32,17 @@ async def _git_push(repo_dir: pathlib.Path) -> tuple[int, str]:
 
 async def _create_submission_commit(repo_dir: pathlib.Path):
     await run_command(["git", "stash", "push"], repo_dir)
-    
+
     await run_command(["git", "commit", "--allow-empty", "-m", "SUBMISSION"], repo_dir)
-    
+
     await run_command(["git", "stash", "pop"], repo_dir)
 
 
 async def git_clone_instructions(repo_dir: pathlib.Path):
     _, ip_address = await run_command(["hostname", "-I"], cwd=repo_dir)
-    _, origin_url = await run_command(["git", "remote", "get-url", "origin"], cwd=repo_dir)
+    _, origin_url = await run_command(
+        ["git", "remote", "get-url", "origin"], cwd=repo_dir
+    )
     click.confirm(
         textwrap.dedent(
             f"""

--- a/src/submit.py
+++ b/src/submit.py
@@ -101,10 +101,8 @@ async def _main(submission: str):
             if clock_status == clock.ClockStatus.STOPPED:
                 return
 
-        for solution_dir in [AGENT_HOME_DIR, AGENT_HOME_DIR / "solution"]:
-            if (solution_dir / ".git").exists():
-                await _check_git_repo(solution_dir)
-                break
+        if (AGENT_HOME_DIR / ".git").exists():
+            await _check_git_repo(AGENT_HOME_DIR)
 
         click.confirm(
             f"Do you definitely want to end the task and submit '{submission}'? This will disconnect you from the task environment and you won't be able to reconnect.",

--- a/src/submit.py
+++ b/src/submit.py
@@ -101,9 +101,10 @@ async def _main(submission: str):
             if clock_status == clock.ClockStatus.STOPPED:
                 return
 
-        solution_dir = AGENT_HOME_DIR / "solution"
-        if (solution_dir / ".git").exists():
-            await _check_git_repo(solution_dir)
+        for solution_dir in [AGENT_HOME_DIR, AGENT_HOME_DIR / "solution"]:
+            if (solution_dir / ".git").exists():
+                await _check_git_repo(solution_dir)
+                break
 
         click.confirm(
             f"Do you definitely want to end the task and submit '{submission}'? This will disconnect you from the task environment and you won't be able to reconnect.",

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -346,15 +346,11 @@ def fixture_mocked_calls(
     repo, _ = git_repo_with_remote
 
     # Mock required paths and user confirmation
-    patches = [
-        ("src.settings.AGENT_HOME_DIR", {"new": repo}),
-        ("src.submit._SUBMISSION_PATH", {"new": tmp_path / "submission.txt"}),
-        ("click.confirm", {"return_value": True}),
-        ("src.clock.get_status", {"return_value": clock.ClockStatus.RUNNING}),
-        ("src.clock.clock", {"return_value": clock.ClockStatus.RUNNING}),
-    ]
-    for target, kwargs in patches:
-        mocker.patch(target, autospec=True, **kwargs)
+    mocker.patch("src.settings.AGENT_HOME_DIR", repo)
+    mocker.patch("src.submit._SUBMISSION_PATH", tmp_path / "submission.txt")
+    mocker.patch("click.confirm", return_value=True, autospec=True)
+    mocker.patch("src.clock.get_status", return_value=clock.ClockStatus.RUNNING, autospec=True)
+    mocker.patch("src.clock.clock", return_value=clock.ClockStatus.RUNNING, autospec=True)
 
     # Create mocks that need to be returned or further configured
     mocked_sleep = mocker.patch("asyncio.sleep", autospec=True, return_value=None)
@@ -366,10 +362,11 @@ def fixture_mocked_calls(
 
 
 @pytest.mark.parametrize("clock_status", ["STOPPED", "RUNNING"])
-@pytest.mark.usefixtures("settings", "git_repo_with_remote")
+@pytest.mark.usefixtures("settings")
 @pytest.mark.asyncio
 async def test_main_success(
     tmp_path: pathlib.Path,
+    git_repo_with_remote: tuple[pathlib.Path, str],
     mocker: MockerFixture,
     clock_status: str,
     mocked_calls: tuple[MockType, MockType, MockType],
@@ -410,10 +407,11 @@ async def test_main_success(
     assert cleanup_mock.call_count == 1
 
 
-@pytest.mark.usefixtures("settings", "git_repo_with_remote")
+@pytest.mark.usefixtures("settings")
 @pytest.mark.asyncio
 async def test_main_no_git_repo(
     tmp_path: pathlib.Path,
+    git_repo_with_remote: tuple[pathlib.Path, str],
     mocker: MockerFixture,
     mocked_calls: tuple[MockType, MockType, MockType],
 ):
@@ -436,10 +434,11 @@ async def test_main_no_git_repo(
     assert cleanup_mock.call_count == 1
 
 
-@pytest.mark.usefixtures("settings", "git_repo_with_remote")
+@pytest.mark.usefixtures("settings")
 @pytest.mark.asyncio
 async def test_main_user_abort_confirmation(
     tmp_path: pathlib.Path,
+    git_repo_with_remote: tuple[pathlib.Path, str],
     mocker: MockerFixture,
     mocked_calls: tuple[MockType, MockType, MockType],
 ):
@@ -465,10 +464,11 @@ async def test_main_user_abort_confirmation(
     mock_hooks.submit.assert_not_called()
 
 
-@pytest.mark.usefixtures("settings", "git_repo_with_remote")
+@pytest.mark.usefixtures("settings")
 @pytest.mark.asyncio
 async def test_main_clock_stays_stopped(
     tmp_path: pathlib.Path,
+    git_repo_with_remote: tuple[pathlib.Path, str],
     mocker: MockerFixture,
     mocked_calls: tuple[MockType, MockType, MockType],
 ):

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -347,10 +347,25 @@ def fixture_mocked_calls(
 
     # Mock required paths and user confirmation
     mocker.patch("src.settings.AGENT_HOME_DIR", repo)
-    mocker.patch("src.submit._SUBMISSION_PATH", tmp_path / "submission.txt")
-    mocker.patch("click.confirm", return_value=True, autospec=True)
-    mocker.patch("src.clock.get_status", return_value=clock.ClockStatus.RUNNING, autospec=True)
-    mocker.patch("src.clock.clock", return_value=clock.ClockStatus.RUNNING, autospec=True)
+    mocker.patch(
+        "src.submit._SUBMISSION_PATH",
+        tmp_path / "submission.txt",
+    )
+    mocker.patch(
+        "click.confirm",
+        return_value=True,
+        autospec=True,
+    )
+    mocker.patch(
+        "src.clock.get_status",
+        return_value=clock.ClockStatus.RUNNING,
+        autospec=True,
+    )
+    mocker.patch(
+        "src.clock.clock",
+        return_value=clock.ClockStatus.RUNNING,
+        autospec=True,
+    )
 
     # Create mocks that need to be returned or further configured
     mocked_sleep = mocker.patch("asyncio.sleep", autospec=True, return_value=None)


### PR DESCRIPTION
There is a git check before submitting, but it looks in /home/agent/submission for git. When running baselines, the home folder gets initialised as a git repo.

This change will check both locations for a git repo. 

I considered just having /home/agent be checked, but there could be some other workflows that expect it to be in /home/agent/submission, and I didn't want to break them

[viv run](https://mp4-server.koi-moth.ts.net/run/#238886/uq)
<img width="814" alt="image" src="https://github.com/user-attachments/assets/c702cba5-4de6-4527-8b92-4d10fb1353da" />


https://github.com/poking-agents/headless-human/issues/47