### PR TITLE
Add reporting score after submission

### DIFF
--- a/src/score.py
+++ b/src/score.py
@@ -44,9 +44,9 @@ async def score():
     )
     output = [get_header("SCORE RESULTS")]
     if result.status == "invalidSubmission":
-        score_message = "Your submission is invalid. Please try again."
+        score_message = "Your submission is invalid."
     elif result.status == "processFailed":
-        score_message = "Scoring failed. Please try again."
+        score_message = "Scoring failed."
     else:
         score_message = f"Score: {result.score}"
 

--- a/src/submit.py
+++ b/src/submit.py
@@ -7,6 +7,7 @@ import aiofiles
 import click
 
 import src.clock as clock
+import src.score as score
 from src.settings import AGENT_HOME_DIR, HOOKS, async_cleanup
 
 _SUBMISSION_PATH = AGENT_HOME_DIR / "submission.txt"
@@ -128,6 +129,8 @@ async def _main(submission: str):
         )
 
     click.echo("Scoring complete! You can exit the task environment now.")
+    click.echo(f'Score:\n {score.log()}')
+    
     await asyncio.sleep(60)
 
     click.echo("Oh, you're still here?")


### PR DESCRIPTION
I believe this is the simplest way to implement this. 

It would require removing the `exit(0)` command from the `Hooks.submit()` method in `vivaria/pyhooks/pyhooks/__init__.py` (https://github.com/METR/vivaria/blame/b50b1c2ff8e0d2581794c057216131479aa7f0ec/pyhooks/pyhooks/__init__.py#L608), as this quits `_main()` in `submit.py` immediately after scoring. I have checked for any calls of `Hooks.submit()` in the `vivaria` repo and think this won't cause any issues, but I'm not sure if there are other repos this is used in.

A more user-friendly alternative would be to send a message to the research log Slack channel once scoring is complete, but this would be considerably more complicated.

Resolves #46, blocked by the `exit(0)` line in the `vivaria` repo mentioned above.