### PR TITLE
Do not overwrite submissions

### DIFF
--- a/src/submit.py
+++ b/src/submit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import pathlib
 
-import aiofiles
 import click
 
 import src.clock as clock
@@ -120,12 +119,13 @@ async def _main(submission: str):
     click.echo("From all of the METR team: thank you for your work!")
     click.echo("Your task is being scored. Please do not make any changes.")
 
-    _SUBMISSION_PATH.parent.mkdir(parents=True, exist_ok=True)
-    async with aiofiles.open(_SUBMISSION_PATH, "w") as f:
-        await asyncio.gather(
-            f.write(submission),
-            HOOKS.submit(submission),
-        )
+    if _SUBMISSION_PATH.exists():
+        submission = _SUBMISSION_PATH.read_text()
+    else:
+        _SUBMISSION_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _SUBMISSION_PATH.write_text(submission)
+
+    await HOOKS.submit(submission)
 
     click.echo("Scoring complete! You can exit the task environment now.")
     await asyncio.sleep(60)

--- a/src/submit.py
+++ b/src/submit.py
@@ -8,8 +8,6 @@ import click
 import src.clock as clock
 from src.settings import AGENT_HOME_DIR, HOOKS, async_cleanup
 
-_SUBMISSION_PATH = AGENT_HOME_DIR / "submission.txt"
-
 
 async def _git_push(repo_dir: pathlib.Path) -> tuple[int, str]:
     process = await asyncio.subprocess.create_subprocess_exec(
@@ -118,12 +116,6 @@ async def _main(submission: str):
     )
     click.echo("From all of the METR team: thank you for your work!")
     click.echo("Your task is being scored. Please do not make any changes.")
-
-    if _SUBMISSION_PATH.exists():
-        submission = _SUBMISSION_PATH.read_text()
-    else:
-        _SUBMISSION_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _SUBMISSION_PATH.write_text(submission)
 
     await HOOKS.submit(submission)
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -296,7 +296,6 @@ def fixture_mocked_calls(
 
     # Mock required paths and user confirmation
     mocker.patch("src.submit.AGENT_HOME_DIR", repo.parent)
-    mocker.patch("src.submit._SUBMISSION_PATH", tmp_path / "submission.txt")
     mocker.patch("click.confirm", return_value=True)
 
     mocked_sleep = mocker.patch("asyncio.sleep", return_value=None)
@@ -334,7 +333,6 @@ async def test_main_success(
     await _main("submission")
 
     # verify that the task was submitted
-    assert (tmp_path / "submission.txt").read_text() == "submission"
     mock_hooks.submit.assert_called_once_with("submission")
 
     # Verify submission commit was created and pushed
@@ -373,7 +371,6 @@ async def test_main_no_git_repo(
     check_git_repo_mock.assert_not_called()
 
     # verify that the task was submitted without git operations
-    assert (tmp_path / "submission.txt").read_text() == "submission"
     mock_hooks.submit.assert_called_once_with("submission")
 
     # verify cleanup
@@ -435,24 +432,3 @@ async def test_main_clock_stays_stopped(
     mocked_sleep.assert_not_called()
     cleanup_mock.assert_not_called()
     mock_hooks.submit.assert_not_called()
-
-
-@pytest.mark.parametrize("clock_status", ["STOPPED", "RUNNING"])
-@pytest.mark.usefixtures("git_repo_with_remote", "mocked_calls")
-@pytest.mark.asyncio
-async def test_main_no_overwrite_submission(
-    tmp_path: pathlib.Path, mocker: MockerFixture, clock_status: str
-):
-    from src.submit import _main
-    import src.clock as clock
-
-    # Mock clock status
-    mocker.patch("src.clock.get_status", return_value=clock.ClockStatus(clock_status))
-    mocker.patch("src.clock.clock", return_value=clock.ClockStatus.RUNNING)
-
-    assert (tmp_path / "submission.txt").write_text("real submission")
-
-    await _main("dummy submission")
-
-    # verify that the task was submitted
-    assert (tmp_path / "submission.txt").read_text() == "real submission"


### PR DESCRIPTION
Tasks which specify that the submission should be provided via `submission.txt` get that overwritten on submission, e.g.

[viv run](https://mp4-server.koi-moth.ts.net/run/#250361/), [submission](https://github.com/evals-sandbox/baseline-collect-personal-info-2025-01-27-igor-hanczaruk/blob/master/submission.txt)  

I considered adding some extra logic where it will write any non empty submissions to the file, but in the case of an empty string just make sure it exists, but that's both more complicated and seems like not what the task specified anyway?

There might actually be more things amiss here, as e.g. [this run](https://mp4-server.koi-moth.ts.net/run/#239671/) submitted the correct answer via `submit`, but the scorer still couldn't see it. I'll play about with that a bit more