### PR TITLE
Replace incorrect github host

### DIFF
--- a/src/submit.py
+++ b/src/submit.py
@@ -69,14 +69,9 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
 
     jumphost_address = await _get_jumphost(repo_dir)
     if jumphost_address:
-        jumphost = f" -J {jumphost_address}"
-        extra_jumphost = (
-            f' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p {jumphost_address}\\"'
-        )
-        extra_jumphost = f'If the clone command fails, try with `GIT_SSH_COMMAND="ssh{extra_jumphost} -i $SSH_KEY"\n`'
+        jumphost = f'GIT_SSH_COMMAND="ssh -J {jumphost_address}" '
     else:
         jumphost = ""
-        extra_jumphost = ""
 
     click.confirm(
         textwrap.dedent(
@@ -88,15 +83,15 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
             to github from there (replace `path/to/ssh/key` with the path to the ssh key 
             you used to connect to this server{origin_desc}):
             
-                SSH_KEY="path/to/ssh/key"
                 {origin_var}
 
-                GIT_SSH_COMMAND="ssh{jumphost} -i $SSH_KEY" git clone agent@{ip_address}:/home/agent baseline-solution
+                ssh-add -t 600 /path/to/ssh/key  # This will add the key for 10 minutes to the ssh-agent
+                {jumphost}git clone agent@{ip_address}:/home/agent baseline-solution
                 git -C baseline-solution remote set-url origin {origin_url}
-                GIT_SSH_COMMAND="ssh -i $SSH_KEY" git -C baseline-solution push
+                git -C baseline-solution push
 
             Refer to the Baselining Handbook for more information.
-            {extra_jumphost}
+            
             ONLY CONFIRM ONCE THIS IS DONE.
             """
         ).format(
@@ -105,7 +100,6 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
             jumphost=jumphost,
             ip_address=ip_address,
             origin_url=origin_url,
-            extra_jumphost=extra_jumphost,
         ),
         abort=True,
     )

--- a/src/submit.py
+++ b/src/submit.py
@@ -58,9 +58,7 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
     origin_desc = ""
     if get_origin_failed or "No such remote" in origin_url:
         origin_url = "$ORIGIN_URL"
-        origin_var = (
-            "ORIGIN_URL=git@github.com:evals-sandbox/baseline-TASK-YYYY-MM-DD-NAME.git"
-        )
+        origin_var = "ORIGIN_URL=git@github.com:evals-sandbox/baseline-TASK-YYYY-MM-DD-NAME.git\n"
         origin_desc = (
             " and replace TASK-YYYY-MM-DD-NAME with whatever\n"
             "is in the name of the slack channel for this task"
@@ -84,7 +82,6 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
             you used to connect to this server{origin_desc}):
             
                 {origin_var}
-
                 ssh-add -t 600 /path/to/ssh/key  # This will add the key for 10 minutes to the ssh-agent
                 {jumphost}git clone agent@{ip_address}:/home/agent baseline-solution
                 git -C baseline-solution remote set-url origin {origin_url}

--- a/src/submit.py
+++ b/src/submit.py
@@ -122,7 +122,7 @@ async def _check_git_repo(repo_dir: pathlib.Path):
 
     await _create_submission_commit(repo_dir)
 
-    if "full internet" not in settings.get_settings().get("task", {}).get(
+    if "full_internet" not in settings.get_settings().get("task", {}).get(
         "permissions", []
     ):
         await git_clone_instructions(repo_dir)

--- a/src/submit.py
+++ b/src/submit.py
@@ -65,6 +65,7 @@ async def git_clone_instructions(repo_dir: pathlib.Path):
             " and replace TASK-YYYY-MM-DD-NAME with whatever\n"
             "is in the name of the slack channel for this task"
         )
+    origin_url = origin_url.replace("ssh://github-metr/", "git@github.com:")
 
     jumphost_address = await _get_jumphost(repo_dir)
     if jumphost_address:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -508,6 +508,17 @@ async def test_main_clock_stays_stopped(
             ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@jumphost1\\"',
             "git@github.com:org/repo.git",
         ),
+        # Remote with hosts entry
+        (
+            (0, "10.0.0.1"),
+            (0, "ssh://github-metr/org/repo.git"),
+            (0, "proxyjump jumphost1"),
+            False,
+            False,
+            " -J ssh-user@jumphost1",
+            ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@jumphost1\\"',
+            "git@github.com:org/repo.git",
+        ),
         # No jumphost config (should use default)
         (
             (0, "192.168.1.1"),

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -84,7 +84,7 @@ def fixture_git_repo_with_remote(
 
 @pytest.fixture(name="settings")
 def fixture_settings(mocker: MockerFixture):
-    settings = {"task": {"permissions": ["full internet"]}}
+    settings = {"task": {"permissions": ["full_internet"]}}
     mocker.patch("src.settings.get_settings", return_value=settings)
     yield settings
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -484,7 +484,7 @@ async def test_main_clock_stays_stopped(
 
 
 @pytest.mark.parametrize(
-    "ip_address_resp, origin_url_resp, ssh_resp, has_origin_desc, has_origin_var, jumphost, extra_jumphost, origin_url",
+    "ip_address_resp, origin_url_resp, ssh_resp, has_origin_desc, has_origin_var, jumphost, origin_url",
     [
         # No remote configured
         (
@@ -493,8 +493,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump stargate"),
             True,
             True,
-            " -J ssh-user@stargate",
-            ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@stargate\\"',
+            "GIT_SSH_COMMAND=\"ssh -J ssh-user@stargate\" ",
             "$ORIGIN_URL",
         ),
         # Existing remote
@@ -504,8 +503,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost1"),
             False,
             False,
-            " -J ssh-user@jumphost1",
-            ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@jumphost1\\"',
+            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost1\" ",
             "git@github.com:org/repo.git",
         ),
         # Remote with hosts entry
@@ -515,8 +513,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost1"),
             False,
             False,
-            " -J ssh-user@jumphost1",
-            ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@jumphost1\\"',
+            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost1\" ",
             "git@github.com:org/repo.git",
         ),
         # No jumphost config (should use default)
@@ -527,7 +524,6 @@ async def test_main_clock_stays_stopped(
             True,
             True,
             "",
-            "",
             "$ORIGIN_URL",
         ),
         # Remote error case
@@ -537,8 +533,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost2"),
             True,
             True,
-            " -J ssh-user@jumphost2",
-            ' -o ProxyCommand=\\"ssh -i $SSH_KEY -W %h:%p ssh-user@jumphost2\\"',
+            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost2\" ",
             "$ORIGIN_URL",
         ),
     ],
@@ -553,7 +548,6 @@ async def test_git_clone_instructions(
     has_origin_desc: bool,
     has_origin_var: bool,
     jumphost: str,
-    extra_jumphost: str,
     origin_url: str,
 ):
     from src.submit import git_clone_instructions
@@ -582,7 +576,7 @@ async def test_git_clone_instructions(
     assert (origin_desc in msg) == has_origin_desc
 
     # Verify clone command
-    expected_clone_command = f'GIT_SSH_COMMAND="ssh{jumphost} -i $SSH_KEY" git clone agent@{ip_address}:/home/agent baseline-solution'
+    expected_clone_command = f'{jumphost}git clone agent@{ip_address}:/home/agent baseline-solution'
     assert expected_clone_command in msg
 
     # Verify remote setup command

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -493,7 +493,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump stargate"),
             True,
             True,
-            "GIT_SSH_COMMAND=\"ssh -J ssh-user@stargate\" ",
+            'GIT_SSH_COMMAND="ssh -J ssh-user@stargate" ',
             "$ORIGIN_URL",
         ),
         # Existing remote
@@ -503,7 +503,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost1"),
             False,
             False,
-            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost1\" ",
+            'GIT_SSH_COMMAND="ssh -J ssh-user@jumphost1" ',
             "git@github.com:org/repo.git",
         ),
         # Remote with hosts entry
@@ -513,7 +513,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost1"),
             False,
             False,
-            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost1\" ",
+            'GIT_SSH_COMMAND="ssh -J ssh-user@jumphost1" ',
             "git@github.com:org/repo.git",
         ),
         # No jumphost config (should use default)
@@ -533,7 +533,7 @@ async def test_main_clock_stays_stopped(
             (0, "proxyjump jumphost2"),
             True,
             True,
-            "GIT_SSH_COMMAND=\"ssh -J ssh-user@jumphost2\" ",
+            'GIT_SSH_COMMAND="ssh -J ssh-user@jumphost2" ',
             "$ORIGIN_URL",
         ),
     ],
@@ -576,7 +576,9 @@ async def test_git_clone_instructions(
     assert (origin_desc in msg) == has_origin_desc
 
     # Verify clone command
-    expected_clone_command = f'{jumphost}git clone agent@{ip_address}:/home/agent baseline-solution'
+    expected_clone_command = (
+        f"{jumphost}git clone agent@{ip_address}:/home/agent baseline-solution"
+    )
     assert expected_clone_command in msg
 
     # Verify remote setup command


### PR DESCRIPTION
baseline_ops sets the origin to be like `ssh://github-metr/evals-sandbox/baseline-agentbench-test-2025-02-11-amritanshu-prasad.git`

I didn't do this in baseline ops, as I was worried it would break things. Let me know if it should go there