### PR TITLE
Fix publish workflow 2: put the poetry-export plugin in the right place

### DIFF
--- a/.github/workflows/pr-and-main.yaml
+++ b/.github/workflows/pr-and-main.yaml
@@ -60,7 +60,9 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          pipx inject poetry poetry-plugin-export
 
       - uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,5 @@ pytest-watcher = "^0.4.3"
 ruff = "^0.6.7"
 uvicorn = "^0.30.6"
 
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.8"
-
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Putting a plugin in pyproject.toml does not help the CI workflow use that plugin if the CI workflow does not run `poetry install`.